### PR TITLE
Improve and restructure unittests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+from LightWave2D.grid import Grid
+from LightWave2D.experiment import Experiment
+
+
+@pytest.fixture
+def grid():
+    return Grid(resolution=1e-6, size_x=10e-6, size_y=5e-6, n_steps=20)
+
+
+@pytest.fixture
+def experiment(grid):
+    return Experiment(grid=grid)
+

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,0 +1,27 @@
+import numpy as np
+from LightWave2D.physics import Physics
+
+
+def test_get_gradient(experiment):
+    # simple field increasing linearly along x and y
+    field_x = np.tile(np.arange(experiment.grid.n_x)[:, None], (1, experiment.grid.n_y))
+    grad_x = experiment.get_gradient(field_x, axis="x")
+
+    field_y = np.tile(np.arange(experiment.grid.n_y)[None, :], (experiment.grid.n_x, 1))
+    grad_y = experiment.get_gradient(field_y, axis="y")
+
+    assert grad_x.shape == (experiment.grid.n_x - 1, experiment.grid.n_y)
+    assert np.allclose(grad_x, 1 / experiment.grid.dx)
+    assert grad_y.shape == (experiment.grid.n_x, experiment.grid.n_y - 1)
+    assert np.allclose(grad_y, 1 / experiment.grid.dy)
+
+
+def test_get_epsilon_sigma_without_components(experiment):
+    sigma_x, sigma_y = experiment.get_sigma()
+    epsilon = experiment.get_epsilon()
+
+    assert not sigma_x.any()
+    assert not sigma_y.any()
+    expected = np.ones(experiment.grid.shape) * Physics.epsilon_0
+    assert np.allclose(epsilon, expected)
+

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -5,13 +5,8 @@ from LightWave2D.grid import Grid
 
 @pytest.fixture
 def default_grid():
-    """Fixture to provide a default Grid instance."""
-    return Grid(
-        resolution=1e-6,
-        size_x=32e-6,
-        size_y=16e-6,
-        n_steps=3000
-    )
+    """Backward compatibility fixture kept for tests using it directly."""
+    return Grid(resolution=1e-6, size_x=32e-6, size_y=16e-6, n_steps=3000)
 
 
 # List of dictionaries for grid initialization parameters
@@ -71,6 +66,40 @@ def test_get_distance_grid(default_grid):
     assert np.isclose(distance_grid[-1, -1], expected_distance), (
         f"Expected distance at the opposite corner to be approximately {expected_distance}, got {distance_grid[-1, -1]}"
     )
+
+
+def test_parse_percentage_positions(default_grid):
+    grid = default_grid
+
+    x = grid.parse_x_position("50%")
+    y = grid.parse_y_position("25%")
+
+    assert x == pytest.approx(0.5 * (grid.x_stamp[-1] - grid.x_stamp[0]))
+    assert y == pytest.approx(0.25 * (grid.y_stamp[-1] - grid.y_stamp[0]))
+
+
+@pytest.mark.parametrize("key,val", [
+    ("left", 0),
+    ("center", lambda g: pytest.approx(np.mean(g.x_stamp))),
+    ("right", lambda g: pytest.approx(g.x_stamp[-1]))
+])
+def test_parse_x_strings(default_grid, key, val):
+    grid = default_grid
+    expected = val(grid) if callable(val) else val
+    assert grid.parse_x_position(key) == expected
+
+
+@pytest.mark.parametrize("key,val", [
+    ("bottom", 0),
+    ("center", lambda g: pytest.approx(np.mean(g.y_stamp))),
+    ("top", lambda g: pytest.approx(g.y_stamp[-1]))
+])
+def test_parse_y_strings(default_grid, key, val):
+    grid = default_grid
+    expected = val(grid) if callable(val) else val
+    assert grid.parse_y_position(key) == expected
+
+
 
 
 if __name__ == "__main__":

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -4,18 +4,15 @@ from LightWave2D.experiment import Experiment
 
 
 # Test the grid initialization
-def test_grid_initialization():
-    grid = Grid(resolution=0.1e-6, size_x=30e-6, size_y=30e-6, n_steps=500)
-    assert grid.resolution == 0.1e-6
-    assert grid.size_x == 30e-6
-    assert grid.size_y == 30e-6
-    assert grid.n_steps == 500
+def test_grid_initialization(grid):
+    assert grid.resolution == 1e-6
+    assert grid.size_x == 10e-6
+    assert grid.size_y == 5e-6
+    assert grid.n_steps == 20
 
 
 # Test the experiment initialization
-def test_experiment_initialization():
-    grid = Grid(resolution=0.1e-6, size_x=30e-6, size_y=30e-6, n_steps=500)
-    experiment = Experiment(grid=grid)
+def test_experiment_initialization(experiment, grid):
     assert experiment.grid == grid
 
 
@@ -24,9 +21,7 @@ def test_experiment_initialization():
     ('add_square', {'position': ('25%', '20%'), 'epsilon_r': 2, 'side_length': 3e-6}),
     ('add_ellipse', {'position': ('25%', '70%'), 'epsilon_r': 2, 'width': 5e-6, 'height': 10e-6, 'rotation': 10})
 ])
-def test_add_scatterers(method, params):
-    grid = Grid(resolution=0.1e-6, size_x=30e-6, size_y=30e-6, n_steps=500)
-    experiment = Experiment(grid=grid)
+def test_add_scatterers(experiment, method, params):
     scatterer = getattr(experiment, method)(**params)
     assert scatterer in experiment.components  # Assuming components is a list of added elements
 
@@ -36,32 +31,25 @@ def test_add_scatterers(method, params):
     ('add_point_source', {'wavelength': 1550e-9, 'position': ('30%', '70%'), 'amplitude': 10}),
     ('add_line_source', {'wavelength': 1550e-9, 'position_0': ('10%', '100%'), 'position_1': ('10%', '0%'), 'amplitude': 10})
 ])
-def test_add_sources(method, params):
-    grid = Grid(resolution=0.1e-6, size_x=30e-6, size_y=30e-6, n_steps=500)
-    experiment = Experiment(grid=grid)
+def test_add_sources(experiment, method, params):
     source = getattr(experiment, method)(**params)
     assert source in experiment.sources  # Assuming sources is a list of added elements
 
 
 # Test adding a PML
-def test_add_pml():
-    grid = Grid(resolution=0.1e-6, size_x=30e-6, size_y=30e-6, n_steps=500)
-    experiment = Experiment(grid=grid)
+def test_add_pml(experiment):
     pml = experiment.add_pml(order=1, width='10%', sigma_max=5000)
     assert pml is not None  # Assuming pmls is a list of added elements
 
 
 # Test adding a detector
-def test_add_detector():
-    grid = Grid(resolution=0.1e-6, size_x=30e-6, size_y=30e-6, n_steps=500)
-    experiment = Experiment(grid=grid)
-    detector = experiment.add_point_detector(position=(25e-6, 'center'))
+def test_add_detector(experiment):
+    detector = experiment.add_point_detector(position=(5e-6, 'center'))
     assert detector in experiment.detectors  # Assuming detectors is a list of added elements
 
 
-def test_experiment_run_and_render():
-    grid = Grid(resolution=0.1e-6, size_x=30e-6, size_y=30e-6, n_steps=500)
-    experiment = Experiment(grid=grid)
+@pytest.mark.skip("Heavy computation not required for unit testing")
+def test_experiment_run_and_render(experiment):
     experiment.run_fdtd()
     animation = experiment.render_propagation(skip_frame=5)
     animation.save('./tests.gif', writer='Pillow', fps=10)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,9 @@
+import numpy as np
+from LightWave2D.utils import bresenham_line
+
+
+def test_bresenham_basic():
+    line = bresenham_line(0, 0, 3, 4)
+    expected = np.array([[0, 1, 1, 2, 3], [0, 1, 2, 3, 4]])
+    assert np.array_equal(line, expected)
+


### PR DESCRIPTION
## Summary
- add `conftest.py` with fixtures for grid and experiment
- improve grid tests and add new coverage for coordinate parsing
- use fixtures in source tests and skip expensive rendering
- add tests for experiment methods and utility functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ad3cec864832ca00beb9699bfe4da