### PR TITLE
Enforce pint unit constants

### DIFF
--- a/LightWave2D/detector.py
+++ b/LightWave2D/detector.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from typing import Tuple, Union, NoReturn
+from typing import Tuple, Any, NoReturn
 from dataclasses import field
 import numpy as np
 from LightWave2D.grid import Grid
@@ -121,7 +121,7 @@ class PointDetector(BaseDetector):
     data : numpy.ndarray
         The data collected by the detector over time.
     """
-    position: Union[Tuple[float, str], Tuple[str, str]]
+    position: Tuple[Any, Any]
     coherent: bool = True
     data: np.ndarray = field(init=False)
 

--- a/LightWave2D/source.py
+++ b/LightWave2D/source.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-from typing import Tuple, NoReturn, List, Union, Optional
+from typing import Tuple, NoReturn, List, Union, Optional, Any
 from LightWave2D.utils import bresenham_line
 from pydantic.dataclasses import dataclass
 from matplotlib.path import Path
@@ -11,6 +11,7 @@ import matplotlib.pyplot as plt
 from LightWave2D.physics import Physics
 from LightWave2D.grid import Grid
 from LightWave2D.binary import SourceInterface
+from LightWave2D.units import to_meters
 
 # Configuration dictionary for dataclasses
 config_dict = {
@@ -69,15 +70,17 @@ class MultiWavelenth:
     delay : Optional[Union[float, List[float], np.ndarray]], optional
         Delay(s) for each wavelength (default is None).
     """
-    wavelength: Union[float, List[float], np.ndarray]
-    amplitude: Union[float, List[float], np.ndarray]
-    delay: Optional[Union[float, List[float], np.ndarray]] = None
+    wavelength: Any
+    amplitude: Any
+    delay: Optional[Any] = None
 
     def init_base_parameters(self) -> NoReturn:
         """
         Initialize the base parameters for the wavelengths.
         """
         self.wavelength = np.atleast_1d(self.wavelength)
+        # Convert wavelength values to meters to ensure consistent units
+        self.wavelength = np.asarray([to_meters(w) for w in self.wavelength])
         self.amplitude = np.atleast_1d(self.amplitude)
 
         if self.wavelength.size != self.amplitude.size:

--- a/LightWave2D/units.py
+++ b/LightWave2D/units.py
@@ -1,13 +1,90 @@
+"""Utility helpers for handling units with :mod:`pint`.
+
+This module exposes Pint's :class:`~pint.Unit` objects so that units can
+be used directly in expressions::
+
+    from LightWave2D.units import nanometer
+    diameter = 50 * nanometer
+
+It also provides small helpers that generate quantities when called with a
+value so that the previous ``units.meters(1)`` style still works.
+"""
+
+from __future__ import annotations
+
 import pint
+
 
 ureg = pint.UnitRegistry()
 Quantity = ureg.Quantity
 
+# expose common units as constants
+meter = ureg.meter
+micrometer = ureg.micrometer
+nanometer = ureg.nanometer
+millimeter = ureg.millimeter
+centimeter = ureg.centimeter
+second = ureg.second
+femtosecond = ureg.femtosecond
+
 
 def to_meters(value) -> float:
-    """Convert a value to meters if it's a pint Quantity or str."""
+    """Return ``value`` converted to meters.
+
+    Parameters
+    ----------
+    value:
+        Either a numeric type, a string with units or a :class:`pint.Quantity`.
+
+    Returns
+    -------
+    float
+        ``value`` expressed in meters.
+    """
     if isinstance(value, pint.Quantity):
         return value.to(ureg.meter).magnitude
     if isinstance(value, str):
         return ureg.Quantity(value).to(ureg.meter).magnitude
     return float(value)
+
+
+def meters(value: float | int) -> Quantity:
+    """Create a quantity expressed in meters."""
+
+    return value * meter
+
+
+def micrometers(value: float | int) -> Quantity:
+    """Create a quantity expressed in micrometers."""
+
+    return value * micrometer
+
+
+def nanometers(value: float | int) -> Quantity:
+    """Create a quantity expressed in nanometers."""
+
+    return value * nanometer
+
+
+def millimeters(value: float | int) -> Quantity:
+    """Create a quantity expressed in millimeters."""
+
+    return value * millimeter
+
+
+def centimeters(value: float | int) -> Quantity:
+    """Create a quantity expressed in centimeters."""
+
+    return value * centimeter
+
+
+def seconds(value: float | int) -> Quantity:
+    """Create a quantity expressed in seconds."""
+
+    return value * second
+
+
+def femtoseconds(value: float | int) -> Quantity:
+    """Create a quantity expressed in femtoseconds."""
+
+    return value * femtosecond

--- a/README.rst
+++ b/README.rst
@@ -78,32 +78,32 @@ Below are two examples that illustrate this:
 
 .. code:: python
 
-   from LightWave2D.grid import Grid
-   from LightWave2D.experiment import Experiment
-   from MPSPlots import colormaps
-   import LightWave2D.units as units
+    from LightWave2D.grid import Grid
+    from LightWave2D.experiment import Experiment
+    from MPSPlots import colormaps
+    import LightWave2D.units as units
 
-   grid = Grid(
-       resolution=units.ureg('0.1 micrometer'),
-       size_x='32 micrometer',
-       size_y=20e-6,
-       n_steps=300
-   )
+    grid = Grid(
+        resolution=0.1 * units.micrometer,
+        size_x=32 * units.micrometer,
+        size_y=20 * units.micrometer,
+        n_steps=300
+    )
 
    experiment = Experiment(grid=grid)
 
-   scatterer = experiment.add_circle(
-       position=('30%', '50%'),
-       epsilon_r=2,
-       radius=3e-6
-   )
+    scatterer = experiment.add_circle(
+        position=('30%', '50%'),
+        epsilon_r=2,
+        radius=3 * units.micrometer
+    )
 
-   source = experiment.add_line_source(
-       wavelength=1550e-9,
-       point_0=('10%', '100%'),
-       point_1=('10%', '0%'),
-       amplitude=10,
-   )
+    source = experiment.add_line_source(
+        wavelength=1550 * units.nanometer,
+        point_0=('10%', '100%'),
+        point_1=('10%', '0%'),
+        amplitude=10,
+    )
 
    experiment.add_pml(order=1, width=70, sigma_max=5000)
 
@@ -130,28 +130,28 @@ Below are two examples that illustrate this:
    from LightWave2D.experiment import Experiment
    from MPSPlots.colormaps import polytechnique
 
-   grid = Grid(
-       resolution=0.1e-6,
-       size_x=50e-6,
-       size_y=30e-6,
-       n_steps=800
-   )
+    grid = Grid(
+        resolution=0.1 * units.micrometer,
+        size_x=50 * units.micrometer,
+        size_y=30 * units.micrometer,
+        n_steps=800
+    )
 
    experiment = Experiment(grid=grid)
 
 
-   scatterer = experiment.add_ring_resonator(
-       position=('35%', '50%'),
-       epsilon_r=1.5,
-       inner_radius=4e-6,
-       width=2e-6
-   )
+    scatterer = experiment.add_ring_resonator(
+        position=('35%', '50%'),
+        epsilon_r=1.5,
+        inner_radius=4 * units.micrometer,
+        width=2 * units.micrometer
+    )
 
-   source = experiment.add_point_source(
-       wavelength=1550e-9,
-       position=('25%', '50%'),
-       amplitude=100,
-   )
+    source = experiment.add_point_source(
+        wavelength=1550 * units.nanometer,
+        position=('25%', '50%'),
+        amplitude=100,
+    )
 
    pml = experiment.add_pml(order=1, width=70, sigma_max=5000)
 
@@ -174,27 +174,27 @@ Below are two examples that illustrate this:
    from LightWave2D.experiment import Experiment
    from MPSPlots import colormaps
 
-   grid = Grid(
-       resolution=0.1e-6,
-       size_x=60e-6,
-       size_y=30e-6,
-       n_steps=1200
-   )
+    grid = Grid(
+        resolution=0.1 * units.micrometer,
+        size_x=60 * units.micrometer,
+        size_y=30 * units.micrometer,
+        n_steps=1200
+    )
 
    experiment = Experiment(grid=grid)
 
-   scatterer = experiment.add_lense(
-       position=('35%', '50%'),
-       epsilon_r=2,
-       curvature=10e-6,
-       width=5e-6
-   )
+    scatterer = experiment.add_lense(
+        position=('35%', '50%'),
+        epsilon_r=2,
+        curvature=10 * units.micrometer,
+        width=5 * units.micrometer
+    )
 
-   source = experiment.add_point_source(
-       wavelength=1550e-9,
-       position=('10%', '50%'),
-       amplitude=10,
-   )
+    source = experiment.add_point_source(
+        wavelength=1550 * units.nanometer,
+        position=('10%', '50%'),
+        amplitude=10,
+    )
 
 
    experiment.add_pml(order=1, width=50, sigma_max=5000)

--- a/docs/examples/detector/source_detector.py
+++ b/docs/examples/detector/source_detector.py
@@ -11,14 +11,15 @@ We will define the simulation grid, add a lens scatterer, a point source, and a 
 from LightWave2D.grid import Grid
 from LightWave2D.experiment import Experiment
 from MPSPlots import colormaps
+import LightWave2D.units as units
 
 # %%
 # Define the simulation grid
 grid = Grid(
-    resolution=0.1e-6,  # Grid resolution in meters
-    size_x=60e-6,       # Grid size in the x direction in meters
-    size_y=30e-6,       # Grid size in the y direction in meters
-    n_steps=100         # Number of time steps for the simulation
+    resolution=0.1 * units.micrometer,
+    size_x=60 * units.micrometer,
+    size_y=30 * units.micrometer,
+    n_steps=100
 )
 
 # Initialize the experiment with the defined grid
@@ -29,14 +30,14 @@ experiment = Experiment(grid=grid)
 scatterer = experiment.add_lense(
     position=('35%', '50%'),  # Center position of the lens
     epsilon_r=2,              # Relative permittivity of the lens
-    curvature=10e-6,          # Curvature of the lens in meters
-    width=5e-6                # Width of the lens in meters
+    curvature=10 * units.micrometer,
+    width=5 * units.micrometer
 )
 
 # %%
 # Add a point source to the experiment
 source = experiment.add_point_source(
-    wavelength=[1310e-9],  # Wavelengths of the source in meters
+    wavelength=[1310 * units.nanometer],
     position=('10%', '50%'),        # Position of the source
     amplitude=10e10                    # Amplitude of the source
 )

--- a/docs/examples/scattering/ellipse.py
+++ b/docs/examples/scattering/ellipse.py
@@ -11,14 +11,15 @@ We will define the simulation grid, add an elliptic scatterer and a line source,
 from LightWave2D.grid import Grid
 from LightWave2D.experiment import Experiment
 from MPSPlots import colormaps
+import LightWave2D.units as units
 
 # %%
 # Define the simulation grid
 grid = Grid(
-    resolution=0.1e-6,  # Grid resolution in meters
-    size_x=40e-6,       # Grid size in the x direction in meters
-    size_y=30e-6,       # Grid size in the y direction in meters
-    n_steps=100        # Number of time steps for the simulation
+    resolution=0.1 * units.micrometer,
+    size_x=40 * units.micrometer,
+    size_y=30 * units.micrometer,
+    n_steps=100
 )
 
 # Initialize the experiment with the defined grid
@@ -28,15 +29,15 @@ experiment = Experiment(grid=grid)
 # Add an elliptic scatterer to the experiment
 scatterer = experiment.add_ellipse(
     position=('30%', '40%'),  # Center position of the ellipse
-    width=4e-6,               # Width of the ellipse in meters
-    height=10e-6,             # Height of the ellipse in meters
+    width=4 * units.micrometer,
+    height=10 * units.micrometer,
     epsilon_r=2               # Relative permittivity of the ellipse
 )
 
 # %%
 # Add a line source to the experiment
 source = experiment.add_line_source(
-    wavelength=1550e-9,       # Wavelength of the source in meters
+    wavelength=1550 * units.nanometer,
     position_0=('10%', '100%'),  # Starting position of the source
     position_1=('10%', '0%'),    # Ending position of the source
     amplitude=10              # Amplitude of the source

--- a/docs/examples/scattering/spherical.py
+++ b/docs/examples/scattering/spherical.py
@@ -11,14 +11,15 @@ We will define the simulation grid, add a circular scatterer and a line source, 
 from LightWave2D.grid import Grid
 from LightWave2D.experiment import Experiment
 from MPSPlots import colormaps
+import LightWave2D.units as units
 
 # %%
 # Define the simulation grid
 grid = Grid(
-    resolution=0.03e-6,  # Grid resolution in meters
-    size_x=32e-6,       # Grid size in the x direction in meters
-    size_y=20e-6,       # Grid size in the y direction in meters
-    n_steps=200         # Number of time steps for the simulation
+    resolution=0.03 * units.micrometer,
+    size_x=32 * units.micrometer,
+    size_y=20 * units.micrometer,
+    n_steps=200
 )
 
 # Initialize the experiment with the defined grid
@@ -29,14 +30,14 @@ experiment = Experiment(grid=grid)
 scatterer = experiment.add_circle(
     position=('30%', '50%'),  # Center position of the scatterer
     epsilon_r=1.5,            # Relative permittivity of the scatterer
-    radius=0.5e-6,              # Radius of the circular scatterer in meters
+    radius=0.5 * units.micrometer,
     sigma=0e6
 )
 
 # %%
 # Add a line source to the experiment
 source = experiment.add_line_source(
-    wavelength=1550e-9,         # Wavelength of the source in meters
+    wavelength=1550 * units.nanometer,
     position_0=('10%', '80%'),  # Starting position of the source
     position_1=('10%', '20%'),  # Ending position of the source
     amplitude=10                # Amplitude of the source

--- a/docs/examples/scattering/spherical_impulsion.py
+++ b/docs/examples/scattering/spherical_impulsion.py
@@ -11,14 +11,15 @@ We will define the simulation grid, add a circular scatterer and a line source, 
 from LightWave2D.grid import Grid
 from LightWave2D.experiment import Experiment
 from MPSPlots import colormaps
+import LightWave2D.units as units
 
 # %%
 # Define the simulation grid
 grid = Grid(
-    resolution=0.2e-6,  # Grid resolution in meters
-    size_x=52e-6,       # Grid size in the x direction in meters
-    size_y=40e-6,       # Grid size in the y direction in meters
-    n_steps=800         # Number of time steps for the simulation
+    resolution=0.2 * units.micrometer,
+    size_x=52 * units.micrometer,
+    size_y=40 * units.micrometer,
+    n_steps=800
 )
 
 # Initialize the experiment with the defined grid
@@ -29,18 +30,18 @@ experiment = Experiment(grid=grid)
 scatterer = experiment.add_circle(
     position=('50%', '50%'),  # Center position of the scatterer
     epsilon_r=2.5,            # Relative permittivity of the scatterer
-    radius=4e-6,              # Radius of the circular scatterer in meters
+    radius=4 * units.micrometer,
     sigma=0e6
 )
 
 # %%
 # Add a line source to the experiment
 source = experiment.add_line_impulsion(
-    duration=1e-15,         # Wavelength of the source in meters
+    duration=1 * units.femtosecond,
     position_0=('30%', '60%'),  # Starting position of the source
     position_1=('30%', '40%'),  # Ending position of the source
     amplitude=1,                # Amplitude of the source
-    delay=0e-14
+    delay=0 * units.femtosecond
 )
 
 # %%

--- a/docs/examples/scattering/square.py
+++ b/docs/examples/scattering/square.py
@@ -11,14 +11,15 @@ We will define the simulation grid, add a square scatterer and a line source, ap
 from LightWave2D.grid import Grid
 from LightWave2D.experiment import Experiment
 from MPSPlots.colormaps import polytechnique
+import LightWave2D.units as units
 
 # %%
 # Define the simulation grid
 grid = Grid(
-    resolution=0.1e-6,  # Grid resolution in meters
-    size_x=4 * 8e-6,    # Grid size in the x direction in meters
-    size_y=4 * 4e-6,    # Grid size in the y direction in meters
-    n_steps=500         # Number of time steps for the simulation
+    resolution=0.1 * units.micrometer,  # Grid resolution
+    size_x=32 * units.micrometer,       # Grid size in the x direction
+    size_y=16 * units.micrometer,       # Grid size in the y direction
+    n_steps=500
 )
 
 # Initialize the experiment with the defined grid
@@ -29,13 +30,13 @@ experiment = Experiment(grid=grid)
 scatterer = experiment.add_square(
     position=('25%', '50%'),  # Center position of the scatterer
     epsilon_r=2,              # Relative permittivity of the scatterer
-    side_length=5e-6          # Side length of the square scatterer in meters
+    side_length=5 * units.micrometer  # Side length of the square scatterer
 )
 
 # %%
 # Add a line source to the experiment
 source = experiment.add_line_source(
-    wavelength=1550e-9,       # Wavelength of the source in meters
+    wavelength=1550 * units.nanometer,  # Wavelength of the source
     position_0=('10%', '100%'),  # Starting position of the source
     position_1=('10%', '0%'),    # Ending position of the source
     amplitude=10              # Amplitude of the source
@@ -52,7 +53,7 @@ experiment.add_pml(
 # %%
 # Add a point detector to the experiment
 detector = experiment.add_point_detector(
-    position=(25e-6, 'center')  # Position of the detector
+    position=(25 * units.micrometer, 'center')  # Position of the detector
 )
 
 # %%

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,17 @@
 import pytest
 from LightWave2D.grid import Grid
 from LightWave2D.experiment import Experiment
+import LightWave2D.units as units
 
 
 @pytest.fixture
 def grid():
-    return Grid(resolution=1e-6, size_x=10e-6, size_y=5e-6, n_steps=20)
+    return Grid(
+        resolution=1 * units.micrometer,
+        size_x=10 * units.micrometer,
+        size_y=5 * units.micrometer,
+        n_steps=20
+    )
 
 
 @pytest.fixture

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,20 +1,46 @@
 import pytest
 import numpy as np
-import pint
 from LightWave2D.grid import Grid
+import LightWave2D.units as units
 
 
 @pytest.fixture
 def default_grid():
     """Backward compatibility fixture kept for tests using it directly."""
-    return Grid(resolution=1e-6, size_x=32e-6, size_y=16e-6, n_steps=3000)
+    return Grid(
+        resolution=1 * units.micrometer,
+        size_x=32 * units.micrometer,
+        size_y=16 * units.micrometer,
+        n_steps=3000
+    )
 
 
 # List of dictionaries for grid initialization parameters
 grid_parameters = [
-    dict(resolution=1e-6, size_x=32e-6, size_y=16e-6, n_steps=3000, expected_n_x=32, expected_n_y=16),
-    dict(resolution=0.5e-6, size_x=64e-6, size_y=32e-6, n_steps=1000, expected_n_x=128, expected_n_y=64),
-    dict(resolution=2e-6, size_x=64e-6, size_y=32e-6, n_steps=5000, expected_n_x=32, expected_n_y=16)
+    dict(
+        resolution=1 * units.micrometer,
+        size_x=32 * units.micrometer,
+        size_y=16 * units.micrometer,
+        n_steps=3000,
+        expected_n_x=32,
+        expected_n_y=16
+    ),
+    dict(
+        resolution=0.5 * units.micrometer,
+        size_x=64 * units.micrometer,
+        size_y=32 * units.micrometer,
+        n_steps=1000,
+        expected_n_x=128,
+        expected_n_y=64
+    ),
+    dict(
+        resolution=2 * units.micrometer,
+        size_x=64 * units.micrometer,
+        size_y=32 * units.micrometer,
+        n_steps=5000,
+        expected_n_x=32,
+        expected_n_y=16
+    )
 ]
 
 
@@ -28,8 +54,9 @@ def test_grid_initialization(params):
     )
     assert grid.n_x == params["expected_n_x"], f"Expected n_x to be {params['expected_n_x']}, got {grid.n_x}"
     assert grid.n_y == params["expected_n_y"], f"Expected n_y to be {params['expected_n_y']}, got {grid.n_y}"
-    assert grid.dx == params["resolution"], f"Expected dx to be {params['resolution']}, got {grid.dx}"
-    assert grid.dy == params["resolution"], f"Expected dy to be {params['resolution']}, got {grid.dy}"
+    expected_res = units.to_meters(params["resolution"])
+    assert grid.dx == expected_res, f"Expected dx to be {expected_res}, got {grid.dx}"
+    assert grid.dy == expected_res, f"Expected dy to be {expected_res}, got {grid.dy}"
     assert grid.n_steps == params["n_steps"], f"Expected n_steps to be {params['n_steps']}, got {grid.n_steps}"
 
 
@@ -102,11 +129,10 @@ def test_parse_y_strings(default_grid, key, val):
 
 
 def test_grid_initialization_with_units():
-    ureg = pint.UnitRegistry()
     grid = Grid(
-        resolution=ureg('1 micrometer'),
-        size_x=ureg.Quantity(32, 'micrometer'),
-        size_y='16 micrometer',
+        resolution=1 * units.micrometer,
+        size_x=32 * units.micrometer,
+        size_y=16 * units.micrometer,
         n_steps=100
     )
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,13 +1,14 @@
 import pytest
 from LightWave2D.grid import Grid
 from LightWave2D.experiment import Experiment
+import LightWave2D.units as units
 
 
 # Test the grid initialization
 def test_grid_initialization(grid):
     assert grid.resolution == 1e-6
-    assert grid.size_x == 10e-6
-    assert grid.size_y == 5e-6
+    assert grid.size_x == pytest.approx(10e-6)
+    assert grid.size_y == pytest.approx(5e-6)
     assert grid.n_steps == 20
 
 
@@ -18,8 +19,24 @@ def test_experiment_initialization(experiment, grid):
 
 # Test adding scatterers
 @pytest.mark.parametrize("method, params", [
-    ('add_square', {'position': ('25%', '20%'), 'epsilon_r': 2, 'side_length': 3e-6}),
-    ('add_ellipse', {'position': ('25%', '70%'), 'epsilon_r': 2, 'width': 5e-6, 'height': 10e-6, 'rotation': 10})
+    (
+        'add_square',
+        {
+            'position': ('25%', '20%'),
+            'epsilon_r': 2,
+            'side_length': units.to_meters(3 * units.micrometer)
+        }
+    ),
+    (
+        'add_ellipse',
+        {
+            'position': ('25%', '70%'),
+            'epsilon_r': 2,
+            'width': units.to_meters(5 * units.micrometer),
+            'height': units.to_meters(10 * units.micrometer),
+            'rotation': 10
+        }
+    )
 ])
 def test_add_scatterers(experiment, method, params):
     scatterer = getattr(experiment, method)(**params)
@@ -28,8 +45,23 @@ def test_add_scatterers(experiment, method, params):
 
 # Test adding sources
 @pytest.mark.parametrize("method, params", [
-    ('add_point_source', {'wavelength': 1550e-9, 'position': ('30%', '70%'), 'amplitude': 10}),
-    ('add_line_source', {'wavelength': 1550e-9, 'position_0': ('10%', '100%'), 'position_1': ('10%', '0%'), 'amplitude': 10})
+    (
+        'add_point_source',
+        {
+            'wavelength': units.to_meters(1550 * units.nanometer),
+            'position': ('30%', '70%'),
+            'amplitude': 10
+        }
+    ),
+    (
+        'add_line_source',
+        {
+            'wavelength': units.to_meters(1550 * units.nanometer),
+            'position_0': ('10%', '100%'),
+            'position_1': ('10%', '0%'),
+            'amplitude': 10
+        }
+    )
 ])
 def test_add_sources(experiment, method, params):
     source = getattr(experiment, method)(**params)
@@ -44,7 +76,7 @@ def test_add_pml(experiment):
 
 # Test adding a detector
 def test_add_detector(experiment):
-    detector = experiment.add_point_detector(position=(5e-6, 'center'))
+    detector = experiment.add_point_detector(position=(units.to_meters(5 * units.micrometer), 'center'))
     assert detector in experiment.detectors  # Assuming detectors is a list of added elements
 
 


### PR DESCRIPTION
## Summary
- expose unit constants like `nanometer` and `micrometer`
- update examples and README to use `1 * units.nanometer` style
- adjust tests to rely on the new unit constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aea3a4718832cbc0343bc9bbaaca8